### PR TITLE
fix image paths

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,26 +1,21 @@
 ---
 import Layout from "~/layouts/Layout.astro";
-import { Image } from '@astrojs/image/components';
-import Hanging from './public/images/hanging.jpg';
+import { Image } from "@astrojs/image/components";
+import hanging from "../assets/images/hanging.jpg";
 
-
-import BasicCTA from "~/astro/ctas/BasicCTA.astro";
-import BasicFeatures from "~/astro/features/BasicFeatures.astro";
-import StepsFeatures from "~/astro/features/StepsFeatures.astro";
-import HeroWithImage from "~/astro/hero/HeroWithImage.astro";
+// import BasicCTA from "~/astro/ctas/BasicCTA.astro";
+// import BasicFeatures from "~/astro/features/BasicFeatures.astro";
+// import StepsFeatures from "~/astro/features/StepsFeatures.astro";
+// import HeroWithImage from "~/astro/hero/HeroWithImage.astro";
 ---
 
-<Layout
-  title="About"
-  description="Humboldt Park Housing Project"
->
+<Layout title="About" description="Humboldt Park Housing Project">
   <main class="mt-20">
-    
     <!-- <HeroWithImage />
-    <BasicFeatures /> 
+    <BasicFeatures />
     <StepsFeatures /> -->
     <!-- <BasicCTA /> -->
-   
+
     <section class="relative">
       <div class="max-w-6xl mx-auto px-4 sm:px-6">
         <div class="pt-20 pb-6 md:pt-20 md:pb-1">
@@ -31,37 +26,47 @@ import HeroWithImage from "~/astro/hero/HeroWithImage.astro";
               What is the Humboldt Park Housing Project?
             </h2>
             <p class="text-xl lg:text-2xl text-gray-600 dark:text-slate-400">
-              Humboldt Park Housing Project is a coalition of community members and activists demanding that Chicago Housing Authority turnover their vacant units to people who need housing. 
+              Humboldt Park Housing Project is a coalition of community members
+              and activists demanding that Chicago Housing Authority turnover
+              their vacant units to people who need housing.
             </p>
           </div>
         </div>
       </div>
     </section>
-    
 
-<section>
-  <div class="max-w-6xl mx-auto px-4 sm:px-6">
-    <div class="py-3 md:py-6">
-      <div class="py-2 sm:py-3 lg:py-8">
-        <div class="w-full place-content-center flex flex-wrap -mx-8">
-          <div class="w-3/5 lg:w-1/2 pb-10 px-1">
-            <Image src={Hanging} 
-            format={"jpeg"}
-            width={490}
-            height={680}/>
-            </div>
-         <div class="w-full lg:w-1/2 px-8"> 
-            <div class="mb-12 lg:mb-0 pb-12 lg:pb-0 border-b lg:border-b-0">
-              <h2 class="mb-4 text-3xl lg:text-4xl font-bold font-heading">
-                In late 2021, the Humboldt Park Housing Project (HPHP) began to occupy vacant public housing after a new homeless encampment opened in our park while our neighborhood is littered with vacant public housing.
-              </h2>
-              <p class="mb-8 text-justify lg:text-justify text-xl text-gray-600 dark:text-gray-400">
-                The group occupied four buildings that had sat vacant for several years due to Chicago Housing Authority’s chronic neglect. 
-On Tuesday, July 26, everyone in these four houses was violently and illegally locked out by Hispanic Housing Development Corporation (HHDC), CHA’s private property management. A week later the press came as they re-occupied their house and forced HHDC and CHA to go through their legal eviction process. 
-Now, we are demanding CHA, HHDC, and all other private management companies immediately desist in illegal lockouts and that vacant public housing be turned over to community members who need housing. 
-
-              </p>
-              <!-- <div class="w-full md:w-1/3">
+    <section>
+      <div class="max-w-6xl mx-auto px-4 sm:px-6">
+        <div class="py-3 md:py-6">
+          <div class="py-2 sm:py-3 lg:py-8">
+            <div class="w-full place-content-center flex flex-wrap -mx-8">
+              <div class="w-3/5 lg:w-1/2 pb-10 px-1">
+                <Image src={hanging} format={"jpeg"} width={490} height={680} />
+              </div>
+              <div class="w-full lg:w-1/2 px-8">
+                <div class="mb-12 lg:mb-0 pb-12 lg:pb-0 border-b lg:border-b-0">
+                  <h2 class="mb-4 text-3xl lg:text-4xl font-bold font-heading">
+                    In late 2021, the Humboldt Park Housing Project (HPHP) began
+                    to occupy vacant public housing after a new homeless
+                    encampment opened in our park while our neighborhood is
+                    littered with vacant public housing.
+                  </h2>
+                  <p
+                    class="mb-8 text-justify lg:text-justify text-xl text-gray-600 dark:text-gray-400"
+                  >
+                    The group occupied four buildings that had sat vacant for
+                    several years due to Chicago Housing Authority’s chronic
+                    neglect. On Tuesday, July 26, everyone in these four houses
+                    was violently and illegally locked out by Hispanic Housing
+                    Development Corporation (HHDC), CHA’s private property
+                    management. A week later the press came as they re-occupied
+                    their house and forced HHDC and CHA to go through their
+                    legal eviction process. Now, we are demanding CHA, HHDC, and
+                    all other private management companies immediately desist in
+                    illegal lockouts and that vacant public housing be turned
+                    over to community members who need housing.
+                  </p>
+                  <!-- <div class="w-full md:w-1/3">
                 <button
                   type="button"
                   class="btn bg-blue-600 hover:bg-blue-700 focus:ring-blue-500 focus:ring-offset-blue-200 text-white transition ease-in duration-200 text-center text-base font-medium shadow-md focus:outline-none focus:ring-2 focus:ring-offset-2"
@@ -69,11 +74,10 @@ Now, we are demanding CHA, HHDC, and all other private management companies imme
                   Donate here
                 </button>
               </div> -->
-            </div>
-          </div>
-          
-          
-          <!-- <div class="w-full lg:w-1/2 px-8">
+                </div>
+              </div>
+
+              <!-- <div class="w-full lg:w-1/2 px-8">
             <ul class="space-y-12">
               <li class="flex -mx-4">
                 <div class="px-4">
@@ -124,12 +128,10 @@ Now, we are demanding CHA, HHDC, and all other private management companies imme
               </li>
             </ul>
           </div> -->
+            </div>
+          </div>
         </div>
       </div>
-    </div>
-  </div>
-</section> 
-
-
+    </section>
   </main>
 </Layout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -6,17 +6,13 @@ import Layout from "~/layouts/Layout.astro";
 // import StepsFeatures from "~/components/astro/features/StepsFeatures.astro";
 ---
 
-<Layout
-  title="HPHP"
-  description="Humboldt Park Housing Project"
->
+<Layout title="HPHP" description="Humboldt Park Housing Project">
   <main class="mt-20">
-    
     <!-- <HeroWithImage />
-    <BasicFeatures /> 
+    <BasicFeatures />
     <StepsFeatures /> -->
     <!-- <BasicCTA /> -->
-   
+
     <section class="relative">
       <div class="max-w-6xl mx-auto px-4 sm:px-6">
         <div class="pt-20 pb-6 md:pt-20 md:pb-1">
@@ -27,34 +23,47 @@ import Layout from "~/layouts/Layout.astro";
               What is the Humboldt Park Housing Project?
             </h2>
             <p class="text-xl lg:text-2xl text-gray-600 dark:text-slate-400">
-              Humboldt Park Housing Project is a coalition of community members and activists demanding that Chicago Housing Authority turnover their vacant units to people who need housing. 
+              Humboldt Park Housing Project is a coalition of community members
+              and activists demanding that Chicago Housing Authority turnover
+              their vacant units to people who need housing.
             </p>
           </div>
         </div>
       </div>
     </section>
-    
 
-<section>
-  <div class="max-w-6xl mx-auto px-4 sm:px-6">
-    <div class="py-3 md:py-6">
-      <div class="py-2 sm:py-3 lg:py-8">
-        <div class="w-full place-content-center flex flex-wrap -mx-8">
-          <div class="w-3/5 lg:w-1/2 pb-10 px-1">
-            <img src="./src/assets/images/hanging.jpg" alt="Hanging banner">
-            </div>
-         <div class="w-full lg:w-1/2 px-8"> 
-            <div class="mb-12 lg:mb-0 pb-12 lg:pb-0 border-b lg:border-b-0">
-              <h2 class="mb-4 text-3xl lg:text-4xl font-bold font-heading">
-                In late 2021, the Humboldt Park Housing Project (HPHP) began to occupy vacant public housing after a new homeless encampment opened in our park while our neighborhood is littered with vacant public housing.
-              </h2>
-              <p class="mb-8 text-justify lg:text-justify text-xl text-gray-600 dark:text-gray-400">
-                The group occupied four buildings that had sat vacant for several years due to Chicago Housing Authority’s chronic neglect. 
-On Tuesday, July 26, everyone in these four houses was violently and illegally locked out by Hispanic Housing Development Corporation (HHDC), CHA’s private property management. A week later the press came as they re-occupied their house and forced HHDC and CHA to go through their legal eviction process. 
-Now, we are demanding CHA, HHDC, and all other private management companies immediately desist in illegal lockouts and that vacant public housing be turned over to community members who need housing. 
-
-              </p>
-              <!-- <div class="w-full md:w-1/3">
+    <section>
+      <div class="max-w-6xl mx-auto px-4 sm:px-6">
+        <div class="py-3 md:py-6">
+          <div class="py-2 sm:py-3 lg:py-8">
+            <div class="w-full place-content-center flex flex-wrap -mx-8">
+              <div class="w-3/5 lg:w-1/2 pb-10 px-1">
+                <img src="images/hanging.jpg" alt="Hanging banner" />
+              </div>
+              <div class="w-full lg:w-1/2 px-8">
+                <div class="mb-12 lg:mb-0 pb-12 lg:pb-0 border-b lg:border-b-0">
+                  <h2 class="mb-4 text-3xl lg:text-4xl font-bold font-heading">
+                    In late 2021, the Humboldt Park Housing Project (HPHP) began
+                    to occupy vacant public housing after a new homeless
+                    encampment opened in our park while our neighborhood is
+                    littered with vacant public housing.
+                  </h2>
+                  <p
+                    class="mb-8 text-justify lg:text-justify text-xl text-gray-600 dark:text-gray-400"
+                  >
+                    The group occupied four buildings that had sat vacant for
+                    several years due to Chicago Housing Authority’s chronic
+                    neglect. On Tuesday, July 26, everyone in these four houses
+                    was violently and illegally locked out by Hispanic Housing
+                    Development Corporation (HHDC), CHA’s private property
+                    management. A week later the press came as they re-occupied
+                    their house and forced HHDC and CHA to go through their
+                    legal eviction process. Now, we are demanding CHA, HHDC, and
+                    all other private management companies immediately desist in
+                    illegal lockouts and that vacant public housing be turned
+                    over to community members who need housing.
+                  </p>
+                  <!-- <div class="w-full md:w-1/3">
                 <button
                   type="button"
                   class="btn bg-blue-600 hover:bg-blue-700 focus:ring-blue-500 focus:ring-offset-blue-200 text-white transition ease-in duration-200 text-center text-base font-medium shadow-md focus:outline-none focus:ring-2 focus:ring-offset-2"
@@ -62,11 +71,10 @@ Now, we are demanding CHA, HHDC, and all other private management companies imme
                   Donate here
                 </button>
               </div> -->
-            </div>
-          </div>
-          
-          
-          <!-- <div class="w-full lg:w-1/2 px-8">
+                </div>
+              </div>
+
+              <!-- <div class="w-full lg:w-1/2 px-8">
             <ul class="space-y-12">
               <li class="flex -mx-4">
                 <div class="px-4">
@@ -117,13 +125,11 @@ Now, we are demanding CHA, HHDC, and all other private management companies imme
               </li>
             </ul>
           </div> -->
+            </div>
+          </div>
         </div>
       </div>
-    </div>
-  </div>
-</section> 
-
-
+    </section>
   </main>
 </Layout>
 
@@ -143,7 +149,7 @@ import HeroWithImage from "~/components/astro/hero/HeroWithImage.astro";
   <main class="mt-20">
     <HeroWithImage />
     <!-- <BasicFeatures />
-    <StepsFeatures /> 
+    <StepsFeatures />
     <BasicCTA />
   </main>
 </Layout> -->

--- a/src/pages/press.astro
+++ b/src/pages/press.astro
@@ -32,7 +32,7 @@ import Layout from "~/layouts/Layout.astro";
         <div class="py-2 sm:py-3 lg:py-4">
           <div class="w-full flex flex-wrap -mx-8">
             <div class="w-full lg:w-1/2 px-8">
-              <div class="mb-12 lg:mb-0 pb-2 lg:pb-0 ">
+              <div class="mb-12 lg:mb-0 pb-2 lg:pb-0">
                 <h2
                   class="mb-4 center text-3xl lg:text-4xl font-bold font-heading"
                 >
@@ -52,7 +52,7 @@ import Layout from "~/layouts/Layout.astro";
               <a
                 href="https://itsgoingdown.org/you-dont-need-a-key-if-you-can-change-the-locks/"
               >
-                <img src="./src/assets/images/igd.jpg" alt="Protest" />
+                <img src="images/igd.jpg" alt="Protest" />
               </a>
             </div>
           </div>
@@ -86,7 +86,7 @@ import Layout from "~/layouts/Layout.astro";
               <a
                 href="https://blockclubchicago.org/2022/08/09/does-public-housing-belong-to-the-public-humboldt-park-squatters-clash-with-developer-cha-over-long-empty-apartments/"
               >
-                <img src="./src/assets/images/wilson.jpg" alt="Protest" />
+                <img src="images/wilson.jpg" alt="Protest" />
               </a>
             </div>
           </div>
@@ -120,7 +120,7 @@ import Layout from "~/layouts/Layout.astro";
               <a
                 href="https://chicago.suntimes.com/2022/8/8/23293490/chicago-housing-authority-cha-owned-house-humboldt-park-protest-occupy"
               >
-                <img src="./src/assets/images/suntimesaug.jpg" alt="cops" />
+                <img src="images/suntimesaug.jpg" alt="cops" />
               </a>
             </div>
           </div>
@@ -140,7 +140,8 @@ import Layout from "~/layouts/Layout.astro";
                   <a
                     href="https://www.chicagotribune.com/news/ct-cha-humboldt-park-residents-occupy-vacant-homes-20220806-ap344mvna5gnlhc7m5kvzwuzuu-story.html"
                     class="text-2xl font-semibold"
-                    >Group wants CHA’s vacant public housing opened up to those facing homelessness
+                    >Group wants CHA’s vacant public housing opened up to those
+                    facing homelessness
                   </a>
                 </h2>
                 <p class="mb-2 text-xl text-gray-600 dark:text-gray-400">
@@ -153,7 +154,7 @@ import Layout from "~/layouts/Layout.astro";
               <a
                 href="https://www.chicagotribune.com/news/ct-cha-humboldt-park-residents-occupy-vacant-homes-20220806-ap344mvna5gnlhc7m5kvzwuzuu-story.html"
               >
-                <img src="./src/assets/images/tribuneaug.jpg" alt="group" />
+                <img src="images/tribuneaug.jpg" alt="group" />
               </a>
             </div>
           </div>
@@ -173,7 +174,8 @@ import Layout from "~/layouts/Layout.astro";
                   <a
                     href="https://www.telemundochicago.com/fotosyvideos/protestan-contra-desalojo-de-personas-de-bajos-recursos-de-una-vivienda-en-humboldt-park/2282712/"
                     class="text-2xl font-semibold"
-                    >Protestan contra desalojo de personas de bajos recursos de una vivienda en Humboldt Park
+                    >Protestan contra desalojo de personas de bajos recursos de
+                    una vivienda en Humboldt Park
                   </a>
                 </h2>
                 <p class="mb-2 text-xl text-gray-600 dark:text-gray-400">
@@ -186,7 +188,7 @@ import Layout from "~/layouts/Layout.astro";
               <a
                 href="https://www.telemundochicago.com/fotosyvideos/protestan-contra-desalojo-de-personas-de-bajos-recursos-de-una-vivienda-en-humboldt-park/2282712/"
               >
-                <img src="./src/assets/images/telemundo.jpg" alt="group" />
+                <img src="images/telemundo.jpg" alt="group" />
               </a>
             </div>
           </div>
@@ -206,7 +208,8 @@ import Layout from "~/layouts/Layout.astro";
                   <a
                     href="https://www.fox32chicago.com/news/chicago-organization-claims-hispanic-housing-development-corporation-isnt-doing-enough-to-fix-up-vacant-homes?"
                     class="text-2xl font-semibold"
-                    >Chicago organization claims Hispanic Housing Development Corporation isn't doing enough to fix up vacant homes
+                    >Chicago organization claims Hispanic Housing Development
+                    Corporation isn't doing enough to fix up vacant homes
                   </a>
                 </h2>
                 <p class="mb-2 text-xl text-gray-600 dark:text-gray-400">
@@ -219,13 +222,12 @@ import Layout from "~/layouts/Layout.astro";
               <a
                 href="https://www.fox32chicago.com/news/chicago-organization-claims-hispanic-housing-development-corporation-isnt-doing-enough-to-fix-up-vacant-homes?%5C"
               >
-                <img src="./src/assets/images/fox32.jpg" alt="group" />
+                <img src="images/fox32.jpg" alt="group" />
               </a>
             </div>
           </div>
         </div>
       </div>
     </div>
-
   </main>
 </Layout>


### PR DESCRIPTION
Sorry for all the noisy whitespace changes! Two main things needed to change:
1. for regular img tags, you need to use the path relative to its place in the `public` folder. so: `images/blah.jpg`
2. when `import`ing the image as a module, you need to use the one in your `src` directory. since the module system ignores everything in the `public` directory at build time, things get explody during the build.

hopefully that makes some sense?